### PR TITLE
Fix MySQL session ID column type error for guest consents

### DIFF
--- a/database/migrations/2_create_user_consents_table.php
+++ b/database/migrations/2_create_user_consents_table.php
@@ -10,7 +10,8 @@ return new class extends Migration
     {
         Schema::create('user_consents', function (Blueprint $table) {
             $table->id();
-            $table->morphs('consentable');
+            $table->string('consentable_type');
+            $table->string('consentable_id');
             $table->foreignId('consent_type_id')->constrained('consent_types')->onDelete('cascade');
             $table->boolean('granted')->default(false);
             $table->timestamp('granted_at')->nullable();


### PR DESCRIPTION
# Fix MySQL Session ID Column Type Error

## Problem
Guest consent operations were failing with MySQL error when trying to revoke consents:

```
SQLSTATE[22007]: Invalid datetime format: 1292 Truncated incorrect DOUBLE value: 'gdpr_zukqryd41_1749917121224' (Connection: mysql, SQL: update `user_consents` set `revoked_at` = 2025-06-14 18:19:13, `granted` = 0, `user_consents`.`updated_at` = 2025-06-14 18:19:13 where `user_consents`.`consentable_type` = Selli\LaravelGdprConsentDatabase\Models\GuestConsent and `user_consents`.`consentable_id` = gdpr_zukqryd41_1749917121224...)
```

## Root Cause
The `user_consents` table migration used Laravel's `$table->morphs('consentable')` helper, which creates:
- `consentable_type` as VARCHAR
- `consentable_id` as **UNSIGNED BIGINT** (integer)

However, the `GuestConsent` model uses string session IDs like `'gdpr_zukqryd41_1749917121224'` as primary keys. When MySQL executes WHERE clauses comparing string session IDs with the integer `consentable_id` column, it attempts to convert the string to a numeric value, causing the truncation error.

## Solution
Changed the polymorphic relationship columns in `user_consents` migration from:
```php
$table->morphs('consentable'); // Creates consentable_id as UNSIGNED BIGINT
```

To explicit string columns:
```php
$table->string('consentable_type');
$table->string('consentable_id');    // Now handles both integer and string IDs
```

## Benefits
- ✅ **MySQL Compatibility**: String session IDs no longer cause type conversion errors
- ✅ **Backward Compatibility**: Integer User IDs still work (Laravel auto-converts integers to strings)
- ✅ **Polymorphic Flexibility**: Supports any model with either integer or string primary keys
- ✅ **Guest Consent Operations**: Consent creation, revocation, and querying work correctly

## Database Compatibility
This change maintains compatibility across all supported databases:
- ✅ SQLite
- ✅ MySQL (resolves the session ID conversion issue)
- ✅ PostgreSQL

## Testing
- ✅ All existing tests pass (41 tests, 159 assertions)
- ✅ Code style validation passes (Laravel Pint)
- ✅ Both User (integer ID) and GuestConsent (string session ID) polymorphic relationships work correctly

## Migration Impact
This is a schema change that affects new installations. For existing installations with data, a separate migration would be needed to alter the column type, but this fix ensures new deployments work correctly with guest consent functionality.

---

**Link to Devin run**: https://app.devin.ai/sessions/7696fa0e21d44424bcde9e2d18cf3af2

**Requested by**: Filippo Calabrese (filippo@selli.io)
