### PR TITLE
build: allow Laravel 13 (illuminate/contracts ^13.0) for Kardyn

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": "^8.2",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^11.0||^12.0"
+        "illuminate/contracts": "^11.0||^12.0||^13.0"
     },
     "require-dev": {
         "larastan/larastan": "^3.10",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line Composer version constraint with no runtime or GDPR logic changes; consumers on Laravel 13 still need compatible dev tooling (e.g. testbench) outside this PR.
> 
> **Overview**
> **Dependency compatibility:** The package can now be installed on **Laravel 13** by widening `illuminate/contracts` from `^11.0||^12.0` to **`^11.0||^12.0||^13.0`** in `composer.json`.
> 
> No application code, tests, or CI matrix changes are included in this diff—only the Composer constraint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 224ced9a5f59930c87f3aa054aa0a431618d76df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Aggiornata la compatibilità delle dipendenze per supportare anche versioni più recenti di Laravel, estendendo il range consentito.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->